### PR TITLE
Report missing data as None and unavailable

### DIFF
--- a/custom_components/absaar_ems/manifest.json
+++ b/custom_components/absaar_ems/manifest.json
@@ -2,7 +2,7 @@
   "domain": "absaar",
   "name": "Absaar Inverter",
   "documentation": "https://www.home-assistant.io/integrations/absaar",
-  "requirements": [],
+  "requirements": ["cachetools"],
   "dependencies": [],
   "codeowners": ["@Pewidot"],
   "version": "1.0"

--- a/custom_components/absaar_ems/sensor.py
+++ b/custom_components/absaar_ems/sensor.py
@@ -126,12 +126,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         for collector in collectors.get("rows", []):
             inverter_id = collector["inverterId"]
-            inverter_data = get_inverter_data(power_id, inverter_id, token)
-            if not inverter_data or "rows" not in inverter_data or not inverter_data["rows"]:
-                _LOGGER.warning("No inverter data found for %s", collector["collectorName"])
-                continue
 
-            inverter = inverter_data["rows"][0]
 
             # Hauptsensor f++r Inverter-Leistung
             entities.append(AbsaarInverterSensor(f"{station['powerName']} Power", power_id, inverter_id, token, "acPower", "W"))
@@ -142,7 +137,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 ("acFrequency", "Hz"),
                 ("pv1Power", "W"),
                 ("pv2Power", "W"),
-                ("temperature", "C"),
+                ("temperature", "°C"),
                 ("pv1Voltage", "V"),
                 ("pv1Electric", "A"),
                 ("pv2Voltage", "V"),
@@ -188,7 +183,8 @@ class AbsaarInverterSensor(SensorEntity):
 
         if not data or "rows" not in data or not data["rows"]:
             _LOGGER.warning("No inverter data received for ID %s", self._inverter_id)
-            self._attr_native_value = "No Data"
+            self._attr_native_value = None
+            self._attr_available = False
             return
 
         inverter = data["rows"][0]
@@ -214,7 +210,7 @@ class AbsaarStationSensor(SensorEntity):
 
         if not data or "rows" not in data or not data["rows"]:
             _LOGGER.warning("No station data received for ID %s", self._power_id)
-            self._attr_native_value = "No Data"
+            self._attr_available = False
             return
 
         station = data["rows"][0]

--- a/custom_components/absaar_ems/sensor.py
+++ b/custom_components/absaar_ems/sensor.py
@@ -210,6 +210,7 @@ class AbsaarStationSensor(SensorEntity):
 
         if not data or "rows" not in data or not data["rows"]:
             _LOGGER.warning("No station data received for ID %s", self._power_id)
+            self._attr_native_value = None
             self._attr_available = False
             return
 


### PR DESCRIPTION
Home Assistant will otherwise try to parse "No Data" as a number and throw an error and potentially not update the other values